### PR TITLE
Add NOFILT mode and PCA dynamics tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,12 @@ jaxfads/
 | Task | Location | Notes |
 |------|----------|-------|
 | Main model class | `src/jaxfads/smoother.py` | `XFADS` |
-| Filtering primitives | `src/jaxfads/core.py` | `filter()`, `smooth()`, `causal()`, `expected_predictive_moment()` |
+| Filtering primitives | `src/jaxfads/core.py` | `filter()`, `smooth()`, `causal()`, `nofilt()`, `expected_predictive_moment()` |
 | Approx posterior families | `src/jaxfads/distributions/` | currently `MVN` |
 | Observation models | `src/jaxfads/observations.py` | `GLM`, `Poisson`, `Gaussian` |
-| Encoders | `src/jaxfads/encoders.py` | `AlphaEncoder`, `BetaEncoder` |
+| Encoders | `src/jaxfads/encoders.py` | `AlphaEncoder`, `BetaEncoder`; user-defined for NOFILT |
 | Training | `src/jaxfads/trainer.py` | `train()`, `batch_loss()`, `DEFAULT_TRAINER_CONFIG` |
-| Abstract interfaces | `src/jaxfads/base.py` | `Approx`, `StateMap`, `Stepper`, `Observation` |
+| Abstract interfaces | `src/jaxfads/base.py` | `Approx`, `StateMap`, `Stepper`, `Observation`, `Encoder` |
 
 ## Core Design Notes
 
@@ -88,6 +88,7 @@ Invariant for callers:
   Encoders are Approx-agnostic and only require:
   - `param_size` (natural-parameter size; injected by `XFADS`)
   - `free_size` (encoder free-form size; injected by `XFADS`)
+  - `state_dim` (latent dimensionality; injected by `XFADS`)
   - `observation_dim` (injected by `XFADS`)
   - encoder hyperparameters (`width`, `depth`, `dropout`)
 

--- a/benchmarks/pca_dynamics_verification.py
+++ b/benchmarks/pca_dynamics_verification.py
@@ -254,6 +254,11 @@ def nofilt_training_comparison():
     z_prev_np = np.asarray(z_pca[:, :-1])
     z_next_np = np.asarray(z_pca[:, 1:])
 
+    pred_identity = z_prev_np
+    rmse_identity = float(
+        np.sqrt(np.mean(np.sum((z_next_np - pred_identity) ** 2, axis=-1)))
+    )
+
     pred_ols = np.einsum("ij,ntj->nti", np.asarray(a_ols), z_prev_np)
     rmse_ols = float(np.sqrt(np.mean(np.sum((z_next_np - pred_ols) ** 2, axis=-1))))
 
@@ -262,8 +267,9 @@ def nofilt_training_comparison():
         np.sqrt(np.mean(np.sum((z_next_np - pred_xfads) ** 2, axis=-1)))
     )
 
-    print(f"OLS pred RMSE:    {rmse_ols:.6f}")
-    print(f"XFADS pred RMSE:  {rmse_xfads:.6f}")
+    print(f"Identity pred RMSE: {rmse_identity:.6f}")
+    print(f"OLS pred RMSE:      {rmse_ols:.6f}")
+    print(f"XFADS pred RMSE:    {rmse_xfads:.6f}")
     print(f"||W_xfads - A_ols||_F: {w_dist:.6f}")
     print(f"\nA_ols:\n{np.asarray(a_ols)}")
     print(f"W_learned:\n{w_learned}")

--- a/benchmarks/pca_dynamics_verification.py
+++ b/benchmarks/pca_dynamics_verification.py
@@ -1,0 +1,98 @@
+"""Direct verification of PCA dynamics gradient equivalence.
+
+Tests the mathematical claim: KL gradient w.r.t. dynamics W converges
+to MSE gradient as posterior variance -> 0.
+
+No encoder, no XFADS pipeline - pure math verification.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaxfads.distributions import MVN
+
+
+def make_stable_A(r=0.95, angle=math.pi / 6):
+    c, s = math.cos(angle), math.sin(angle)
+    return r * np.array([[c, -s], [s, c]], dtype=np.float32)
+
+
+def generate_pca_coords(seed=0, n_trials=64, T=50, state_dim=2, obs_dim=10):
+    """Generate synthetic data and return PCA coordinates."""
+    rng = np.random.default_rng(seed)
+    A_true = make_stable_A()
+    C_true = rng.normal(size=(obs_dim, state_dim)).astype(np.float32)
+    b_true = rng.normal(size=(obs_dim,)).astype(np.float32)
+
+    z = np.zeros((n_trials, T, state_dim), dtype=np.float32)
+    y = np.zeros((n_trials, T, obs_dim), dtype=np.float32)
+    for n in range(n_trials):
+        z_prev = rng.normal(size=(state_dim,)).astype(np.float32)
+        for t in range(T):
+            if t > 0:
+                z_prev = (A_true @ z_prev + 0.1 * rng.normal(size=(state_dim,))).astype(
+                    np.float32
+                )
+            z[n, t] = z_prev
+            y[n, t] = (
+                C_true @ z_prev + b_true + 0.5 * rng.normal(size=(obs_dim,))
+            ).astype(np.float32)
+
+    y_flat = y.reshape(-1, obs_dim)
+    b_pca = y_flat.mean(0)
+    y_c = y_flat - b_pca
+    _, _, vt = np.linalg.svd(y_c, full_matrices=False)
+    C_pca = vt[:state_dim].T
+    z_pca = ((y.reshape(-1, obs_dim) - b_pca) @ C_pca).reshape(
+        n_trials, T, state_dim
+    ).astype(np.float32)
+    return z_pca
+
+
+def main():
+    z_pca = jnp.asarray(generate_pca_coords())
+    _, T, D = z_pca.shape
+
+    z_prev = z_pca[:, :-1].reshape(-1, D)
+    z_next = z_pca[:, 1:].reshape(-1, D)
+    A_ols = (z_next.T @ z_prev) @ jnp.linalg.inv(z_prev.T @ z_prev)
+
+    W = A_ols
+    Q = jnp.eye(D)
+    approx = MVN(dim=D, rank=D)
+    N_pairs = z_prev.shape[0]
+
+    residuals = z_next - z_prev @ W.T
+    grad_mse_W = -(residuals.T @ z_prev) / N_pairs
+
+    epsilons = [1.0, 0.1, 0.01, 0.001, 1e-4, 1e-5]
+
+    print("eps      | cos_sim  | norm_ratio | angle_deg")
+    print("---------|----------|------------|----------")
+
+    for eps in epsilons:
+
+        def kl_loss(W_param):
+            cov_q = eps * jnp.eye(D)
+            moment_q = jax.vmap(lambda mq: approx.pack(mq, cov_q))(z_next)
+            m_p = z_prev @ W_param.T
+            moment_p = jax.vmap(lambda mp: approx.pack(mp, Q))(m_p)
+            kl_vals = jax.vmap(approx.kl)(moment_q, moment_p)
+            return jnp.mean(kl_vals)
+
+        grad_kl_W = jax.grad(kl_loss)(W)
+
+        g1 = grad_kl_W.ravel()
+        g2 = grad_mse_W.ravel()
+        cos_sim = float(jnp.dot(g1, g2) / (jnp.linalg.norm(g1) * jnp.linalg.norm(g2)))
+        norm_ratio = float(jnp.linalg.norm(g1) / jnp.linalg.norm(g2))
+        angle = float(jnp.degrees(jnp.arccos(jnp.clip(cos_sim, -1, 1))))
+
+        print(f"{eps:<8g} | {cos_sim:>8.5f} | {norm_ratio:>10.4f} | {angle:>9.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/pca_dynamics_verification.py
+++ b/benchmarks/pca_dynamics_verification.py
@@ -1,18 +1,90 @@
-"""Direct verification of PCA dynamics gradient equivalence.
+"""PCA dynamics verification.
 
-Tests the mathematical claim: KL gradient w.r.t. dynamics W converges
-to MSE gradient as posterior variance -> 0.
+Section 1: direct gradient equivalence check (KL vs MSE gradients).
+Section 2: NOFILT end-to-end training with fixed PCA encoder/observation.
 
-No encoder, no XFADS pipeline - pure math verification.
+Run with:
+    uv run python benchmarks/pca_dynamics_verification.py
 """
+
+from __future__ import annotations
 
 import math
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
+from omegaconf import OmegaConf
+import tensorflow_probability.substrates.jax.distributions as tfp
 
+from jaxfads import XFADS
+from jaxfads.base import Encoder, Observation, Approx, StateMap
 from jaxfads.distributions import MVN
+from jaxfads.trainer import train
+
+
+class PCAEncoder(Encoder):
+    """Fixed PCA projection: z = C^T(y - b). No trainable parameters."""
+
+    weight: jax.Array
+    bias: jax.Array
+
+    def __init__(self, conf, key=None):
+        del key
+        self.conf = conf
+        self.weight = jnp.zeros((int(conf.observation_dim), int(conf.state_dim)))
+        self.bias = jnp.zeros((int(conf.observation_dim),))
+
+    def __call__(self, y, *, key=None):
+        del key
+        return (y - self.bias) @ self.weight
+
+
+class PCAObservation(Observation):
+    """Fixed Gaussian observation with PCA readout. No trainable parameters."""
+
+    weight: jax.Array
+    bias: jax.Array
+    obs_var: float
+
+    def __init__(self, conf, key=None):
+        del key
+        self.conf = conf
+        d_obs = int(conf.observation_dim)
+        d_state = int(conf.state_dim)
+        self.weight = jnp.zeros((d_obs, d_state))
+        self.bias = jnp.zeros((d_obs,))
+        self.obs_var = float(conf.get("obs_var", 1e-4))
+
+    def eloglik(self, key, t, moment, y, approx: Approx, mc_size):
+        del key, t, mc_size
+        mean_z, cov_z = approx.unpack(moment)
+        c = self.weight
+        b = self.bias
+        mean_y = c @ mean_z + b
+        cov_y = c @ cov_z @ c.T + self.obs_var * jnp.eye(c.shape[0], dtype=cov_z.dtype)
+        return tfp.MultivariateNormalFullCovariance(mean_y, cov_y).log_prob(y)
+
+    def initialize(self, t, y, u, c):
+        del t, y, u, c
+        return self
+
+
+class LinearStateMap(StateMap):
+    """Learnable linear discrete map: z_t = W @ z_{t-1}."""
+
+    W: jax.Array
+
+    def __init__(self, conf, key):
+        self.conf = conf
+        d = int(conf.state_dim)
+        self.W = 0.9 * jnp.eye(d) + 0.01 * jr.normal(key, (d, d))
+
+    def eval(self, z, u, c, *, key=None):
+        del u, c, key
+        return self.W @ z
 
 
 def make_stable_A(r=0.95, angle=math.pi / 6):
@@ -20,11 +92,11 @@ def make_stable_A(r=0.95, angle=math.pi / 6):
     return r * np.array([[c, -s], [s, c]], dtype=np.float32)
 
 
-def generate_pca_coords(seed=0, n_trials=64, T=50, state_dim=2, obs_dim=10):
-    """Generate synthetic data and return PCA coordinates."""
+def generate_pca_data(seed=0, n_trials=64, T=50, state_dim=2, obs_dim=10):
+    """Generate synthetic data, then PCA-project observations."""
     rng = np.random.default_rng(seed)
-    A_true = make_stable_A()
-    C_true = rng.normal(size=(obs_dim, state_dim)).astype(np.float32)
+    a_true = make_stable_A()
+    c_true = rng.normal(size=(obs_dim, state_dim)).astype(np.float32)
     b_true = rng.normal(size=(obs_dim,)).astype(np.float32)
 
     z = np.zeros((n_trials, T, state_dim), dtype=np.float32)
@@ -33,40 +105,41 @@ def generate_pca_coords(seed=0, n_trials=64, T=50, state_dim=2, obs_dim=10):
         z_prev = rng.normal(size=(state_dim,)).astype(np.float32)
         for t in range(T):
             if t > 0:
-                z_prev = (A_true @ z_prev + 0.1 * rng.normal(size=(state_dim,))).astype(
+                z_prev = (a_true @ z_prev + 0.1 * rng.normal(size=(state_dim,))).astype(
                     np.float32
                 )
             z[n, t] = z_prev
             y[n, t] = (
-                C_true @ z_prev + b_true + 0.5 * rng.normal(size=(obs_dim,))
+                c_true @ z_prev + b_true + 0.5 * rng.normal(size=(obs_dim,))
             ).astype(np.float32)
 
     y_flat = y.reshape(-1, obs_dim)
     b_pca = y_flat.mean(0)
-    y_c = y_flat - b_pca
-    _, _, vt = np.linalg.svd(y_c, full_matrices=False)
-    C_pca = vt[:state_dim].T
-    z_pca = ((y.reshape(-1, obs_dim) - b_pca) @ C_pca).reshape(
+    y_centered = y_flat - b_pca
+    _, _, vt = np.linalg.svd(y_centered, full_matrices=False)
+    c_pca = vt[:state_dim].T.astype(np.float32)
+    z_pca = ((y.reshape(-1, obs_dim) - b_pca) @ c_pca).reshape(
         n_trials, T, state_dim
     ).astype(np.float32)
-    return z_pca
+
+    return z_pca, y, c_pca, b_pca.astype(np.float32)
 
 
-def main():
-    z_pca = jnp.asarray(generate_pca_coords())
-    _, T, D = z_pca.shape
+def gradient_comparison():
+    z_pca, _, _, _ = generate_pca_data()
+    z_pca = jnp.asarray(z_pca)
+    _, _, d = z_pca.shape
 
-    z_prev = z_pca[:, :-1].reshape(-1, D)
-    z_next = z_pca[:, 1:].reshape(-1, D)
-    A_ols = (z_next.T @ z_prev) @ jnp.linalg.inv(z_prev.T @ z_prev)
+    z_prev = z_pca[:, :-1].reshape(-1, d)
+    z_next = z_pca[:, 1:].reshape(-1, d)
+    a_ols = (z_next.T @ z_prev) @ jnp.linalg.inv(z_prev.T @ z_prev)
 
-    W = A_ols
-    Q = jnp.eye(D)
-    approx = MVN(dim=D, rank=D)
-    N_pairs = z_prev.shape[0]
+    w = a_ols
+    q = jnp.eye(d)
+    approx = MVN(dim=d, rank=d)
 
-    residuals = z_next - z_prev @ W.T
-    grad_mse_W = -(residuals.T @ z_prev) / N_pairs
+    residuals = z_next - z_prev @ w.T
+    grad_mse_w = -(residuals.T @ z_prev) / z_prev.shape[0]
 
     epsilons = [1.0, 0.1, 0.01, 0.001, 1e-4, 1e-5]
 
@@ -75,23 +148,132 @@ def main():
 
     for eps in epsilons:
 
-        def kl_loss(W_param):
-            cov_q = eps * jnp.eye(D)
-            moment_q = jax.vmap(lambda mq: approx.pack(mq, cov_q))(z_next)
-            m_p = z_prev @ W_param.T
-            moment_p = jax.vmap(lambda mp: approx.pack(mp, Q))(m_p)
+        def kl_loss(w_param):
+            cov_q = eps * jnp.eye(d)
+            moment_q = jax.vmap(lambda m: approx.pack(m, cov_q))(z_next)
+            m_p = z_prev @ w_param.T
+            moment_p = jax.vmap(lambda m: approx.pack(m, q))(m_p)
             kl_vals = jax.vmap(approx.kl)(moment_q, moment_p)
             return jnp.mean(kl_vals)
 
-        grad_kl_W = jax.grad(kl_loss)(W)
+        grad_kl_w = jax.grad(kl_loss)(w)
 
-        g1 = grad_kl_W.ravel()
-        g2 = grad_mse_W.ravel()
+        g1 = grad_kl_w.ravel()
+        g2 = grad_mse_w.ravel()
         cos_sim = float(jnp.dot(g1, g2) / (jnp.linalg.norm(g1) * jnp.linalg.norm(g2)))
         norm_ratio = float(jnp.linalg.norm(g1) / jnp.linalg.norm(g2))
         angle = float(jnp.degrees(jnp.arccos(jnp.clip(cos_sim, -1, 1))))
 
         print(f"{eps:<8g} | {cos_sim:>8.5f} | {norm_ratio:>10.4f} | {angle:>9.3f}")
+
+
+def nofilt_training_comparison():
+    """Section 2: NOFILT end-to-end — train dynamics, compare to OLS."""
+    print("\n=== Section 2: NOFILT end-to-end training ===")
+
+    n_trials, T, state_dim, obs_dim = 256, 50, 2, 10
+    z_pca, y, c_pca, b_pca = generate_pca_data(
+        seed=0, n_trials=n_trials, T=T, state_dim=state_dim, obs_dim=obs_dim
+    )
+
+    z_prev = jnp.asarray(z_pca[:, :-1].reshape(-1, state_dim))
+    z_next = jnp.asarray(z_pca[:, 1:].reshape(-1, state_dim))
+    a_ols = (z_next.T @ z_prev) @ jnp.linalg.inv(z_prev.T @ z_prev)
+
+    conf = OmegaConf.create(
+        {
+            "mode": "nofilt",
+            "state_dim": state_dim,
+            "observation_dim": obs_dim,
+            "seed": 0,
+            "mc_size": 8,
+            "approx": "MVN",
+            "approx_kwargs": {},
+            "state_map": "LinearStateMap",
+            "stepper": "DiscreteStepper",
+            "dropout": 0.0,
+            "nofilt_eps": 1e-6,
+            "dyn_conf": {
+                "system_type": "discrete",
+                "state_noise": 0.1,
+                "input_dim": 0,
+                "context_dim": 0,
+            },
+            "enc_conf": {
+                "alpha_encoder": "PCAEncoder",
+            },
+            "obs_conf": {
+                "model": "PCAObservation",
+                "obs_var": 1e-4,
+            },
+        }
+    )
+
+    model = XFADS(conf, jr.key(0))
+
+    c_enc = jnp.asarray(np.array(c_pca, copy=True))
+    b_enc = jnp.asarray(np.array(b_pca, copy=True))
+    c_obs = jnp.asarray(np.array(c_pca, copy=True))
+    b_obs = jnp.asarray(np.array(b_pca, copy=True))
+    model = eqx.tree_at(
+        lambda m: (
+            m.alpha_encoder.weight,
+            m.alpha_encoder.bias,
+            m.observation.weight,
+            m.observation.bias,
+        ),
+        model,
+        (c_enc, b_enc, c_obs, b_obs),
+    )
+
+    times = jnp.tile(jnp.arange(T)[None, :], (n_trials, 1))
+    observations = jnp.asarray(y)
+    controls = jnp.zeros((n_trials, T, 0))
+    covariates = jnp.zeros((n_trials, T, 0))
+    data = (times, observations, controls, covariates)
+
+    trainer_conf = OmegaConf.create(
+        {
+            "seed": 0,
+            "learning_rate": 1e-2,
+            "min_epoch": 300,
+            "max_epoch": 300,
+            "patience": 100,
+            "batch_size": 64,
+            "validation_size": 32,
+            "weight_decay": 0.0,
+            "freeze_paths": ["alpha_encoder", "observation", "noise_free"],
+        }
+    )
+
+    trained = train(model, data, conf=trainer_conf)
+
+    w_learned = np.asarray(trained.state_map.W)
+    w_dist = float(np.linalg.norm(w_learned - np.asarray(a_ols), ord="fro"))
+
+    z_prev_np = np.asarray(z_pca[:, :-1])
+    z_next_np = np.asarray(z_pca[:, 1:])
+
+    pred_ols = np.einsum("ij,ntj->nti", np.asarray(a_ols), z_prev_np)
+    rmse_ols = float(np.sqrt(np.mean(np.sum((z_next_np - pred_ols) ** 2, axis=-1))))
+
+    pred_xfads = np.einsum("ij,ntj->nti", w_learned, z_prev_np)
+    rmse_xfads = float(
+        np.sqrt(np.mean(np.sum((z_next_np - pred_xfads) ** 2, axis=-1)))
+    )
+
+    print(f"OLS pred RMSE:    {rmse_ols:.6f}")
+    print(f"XFADS pred RMSE:  {rmse_xfads:.6f}")
+    print(f"||W_xfads - A_ols||_F: {w_dist:.6f}")
+    print(f"\nA_ols:\n{np.asarray(a_ols)}")
+    print(f"W_learned:\n{w_learned}")
+
+
+def main():
+    print("=== Section 1: Gradient equivalence ===")
+    gradient_comparison()
+    print()
+    nofilt_training_comparison()
 
 
 if __name__ == "__main__":

--- a/docs/dynamics.md
+++ b/docs/dynamics.md
@@ -47,6 +47,7 @@ class MyStateMap(StateMap):
 
 ## Built-in StateMap
 
+- `IdentityStateMap`: discrete random-walk mean map `z_{t+1} = z_t`
 - `OUStateMap`: continuous OU drift map `dz/dt = -theta * z`
 - `FunctionStateMap`: wraps a non-trainable callable
 
@@ -91,7 +92,23 @@ dyn_conf:
   context_dim: 0
 ```
 
-## Configuration Example (Discrete)
+## Configuration Example (Identity / random-walk baseline)
+
+```yaml
+state_map: IdentityStateMap
+stepper: DiscreteStepper
+
+dyn_conf:
+  system_type: discrete
+  state_noise: 1.0
+  input_dim: 0
+  context_dim: 0
+```
+
+Use this as the weakest built-in dynamics prior when you want
+`z_{t+1} \approx z_t + noise`.
+
+## Configuration Example (Discrete custom map)
 
 ```yaml
 state_map: MyStateMap

--- a/docs/pca_dynamics_equivalence.md
+++ b/docs/pca_dynamics_equivalence.md
@@ -98,3 +98,11 @@ Dynamics receive gradient through **two paths**:
 
 The latent trajectory is **dynamics-smoothed** rather than raw PCA, yielding
 a more robust dynamics estimate.
+
+## NOFILT mode
+
+The `nofilt` inference mode implements the $\sigma^2 \to 0$ limiting case
+directly: the posterior is set by a user-provided encoder (bypassing
+filtering), and dynamics are trained via the KL term alone. See the
+[workflow guide](pca_dynamics_workflow.md#alternative-nofilt-mode) for
+configuration details.

--- a/docs/pca_dynamics_workflow.md
+++ b/docs/pca_dynamics_workflow.md
@@ -236,3 +236,23 @@ Key differences from the `smooth` workflow:
    the next encoder output.
 5. The observation log-likelihood term still contributes if the readout is
    trainable.
+
+### Identity baseline
+
+For PCA / NOFILT experiments, `IdentityStateMap` is a good null-dynamics
+baseline:
+
+```python
+"state_map": "IdentityStateMap",
+"stepper": "DiscreteStepper",
+"dyn_conf": {
+    "system_type": "discrete",
+    "state_noise": 1.0,
+    "input_dim": 0,
+    "context_dim": 0,
+},
+```
+
+This corresponds to the random-walk prior `z_{t+1} = z_t + noise`. Use it to
+check whether a learned dynamics model improves over simple persistence in PCA
+coordinates.

--- a/docs/pca_dynamics_workflow.md
+++ b/docs/pca_dynamics_workflow.md
@@ -160,3 +160,79 @@ equals the MSE gradient on PCA coordinates
 ([proof](pca_dynamics_equivalence.md)). With finite $\sigma^2$, the XFADS
 estimate is strictly richer because dynamics also receive gradient through
 the posterior's dependence on $f$.
+
+## Alternative: NOFILT mode
+
+The workflow above uses `mode="smooth"` with small observation noise so the
+encoder learns posteriors near PCA coordinates while filtering still runs.
+An alternative is `mode="nofilt"`, which **bypasses filtering entirely**: the
+posterior at each timestep is set directly by a user-defined encoder, and
+dynamics are trained purely through the KL term.
+
+### When to use NOFILT
+
+- You have a **pretrained** dimensionality reduction (PCA, autoencoder, etc.)
+  and want to fit dynamics to its output without the filtering recursion
+  influencing the latent trajectory.
+- The encoder is non-trainable — its output defines the latent coordinates.
+
+### Defining a custom encoder
+
+In NOFILT mode you provide your own `Encoder` subclass. The encoder maps a
+single observation to a point estimate of the latent state:
+
+```python
+import jax.numpy as jnp
+from jax import Array
+from jaxfads.base import Encoder
+
+class PCAEncoder(Encoder):
+    """Project observations to PCA coordinates."""
+    weight: Array   # (obs_dim, state_dim) — PCA loadings
+    bias: Array     # (obs_dim,) — observation mean
+
+    def __init__(self, conf, key=None):
+        self.conf = conf
+        # Load your pretrained PCA parameters here
+        self.weight = ...  # C_pca
+        self.bias = ...    # mean_y
+
+    def __call__(self, y: Array, *, key=None) -> Array:
+        return (y - self.bias) @ self.weight
+```
+
+### Configuration
+
+```python
+conf = OmegaConf.create(
+    {
+        "mode": "nofilt",
+        "state_dim": state_dim,
+        "observation_dim": obs_dim,
+        "nofilt_eps": 1e-6,   # tight MVN variance wrapping point estimates
+        "enc_conf": {
+            "alpha_encoder": "PCAEncoder",
+        },
+        # ... dynamics and observation config as before ...
+    }
+)
+```
+
+Key differences from the `smooth` workflow:
+- `mode: "nofilt"` — no filtering recursion.
+- `enc_conf.alpha_encoder` — name of your custom `Encoder` subclass.
+- `nofilt_eps` — the point estimate is wrapped as `MVN(z_hat, eps * I)` for
+  framework compatibility (sampling, KL computation).
+- No beta encoder is constructed.
+- The encoder is typically frozen via `freeze_paths: ["alpha_encoder"]`.
+
+### How it works
+
+1. Your encoder maps each observation to a point estimate `z_hat`.
+2. XFADS wraps it as a tight MVN: `q(z_t) = N(z_hat, eps * I)`.
+3. Dynamics predictions `p(z_t | z_{t-1})` are computed in parallel (no
+   sequential filtering).
+4. The ELBO's KL term `KL(q_t || p_pred_t)` trains the dynamics to predict
+   the next encoder output.
+5. The observation log-likelihood term still contributes if the readout is
+   trainable.

--- a/docs/pca_dynamics_workflow.md
+++ b/docs/pca_dynamics_workflow.md
@@ -1,0 +1,162 @@
+# Learning Dynamics from PCA Coordinates
+
+This page shows how to use XFADS with frozen PCA readout to learn latent
+dynamics from principal components — using the standard MVN posterior, no
+special approximation family needed.
+
+See also: [PCA Dynamics Equivalence Proof](pca_dynamics_equivalence.md),
+[Quickstart](quickstart.md), [Training Configuration](training.md).
+
+## Motivation
+
+Given high-dimensional observations $y_t$, a common workflow is:
+
+1. Run PCA to get low-dimensional coordinates $z_t^{\mathrm{PCA}}$.
+2. Fit a dynamical model $z_t \approx f(z_{t-1})$ to these coordinates.
+
+Step 2 is typically done via MSE regression on PCA coordinates. XFADS can
+do the same thing — and more — by treating PCA as a **Gaussian observation
+model** within a proper Bayesian state-space framework.
+
+With small observation noise $\sigma^2$, the posterior is close to PCA
+coordinates and dynamics estimation is equivalent to MSE regression
+([proof](pca_dynamics_equivalence.md)). With moderate $\sigma^2$, the
+posterior is **dynamics-smoothed**, yielding more robust estimates.
+
+## Configuration
+
+```python
+from omegaconf import OmegaConf
+
+state_dim = 4       # PCA rank
+obs_dim = 50        # observation dimensionality
+sigma2 = 1e-4       # observation noise (small = near-PCA limit)
+
+conf = OmegaConf.create(
+    {
+        "mode": "smooth",
+        "state_dim": state_dim,
+        "observation_dim": obs_dim,
+        "seed": 0,
+        "mc_size": 4,
+        "approx": "MVN",
+        "approx_kwargs": {},
+        "state_map": "OUStateMap",       # or any dynamics model
+        "stepper": "EulerStepper",
+        "dropout": 0.0,
+        "dyn_conf": {
+            "system_type": "continuous",
+            "theta": 2.0,
+            "dt": 0.05,
+            "state_noise": 1.0,
+            "input_dim": 0,
+            "context_dim": 0,
+        },
+        "enc_conf": {
+            "width": 64,
+            "depth": 1,
+            "dropout": 0.0,
+        },
+        "obs_conf": {
+            "model": "GLM",
+            "likelihood": "Gaussian",
+            "cov": [sigma2] * obs_dim,
+            "norm_readout": False,
+            # FA with obs_noise_var=0 gives exact PCA loadings.
+            "readout_init": "fa",
+            "readout_init_conf": {"obs_noise_var": 0.0},
+        },
+    }
+)
+```
+
+## Key settings explained
+
+### Observation noise `cov`
+
+Controls how strongly observations pin the posterior to PCA coordinates:
+
+| `sigma2` | Posterior behaviour | Dynamics estimate |
+|----------|--------------------|--------------------|
+| `1e-6` | ≈ raw PCA projection | ≈ MSE on PCs |
+| `1e-4` | near-PCA, numerically stable | near-MSE, stable |
+| `1e-1` | dynamics-smoothed | richer than MSE |
+| `1.0` | balanced obs/dynamics | full Bayesian |
+
+**Do not use exactly zero** — the Gaussian likelihood becomes
+ill-conditioned. Use a small positive value like `1e-4`.
+
+### Readout initialisation
+
+Setting `readout_init_conf.obs_noise_var = 0.0` makes the FA initialiser
+produce **exact PCA loadings** (no noise subtraction from the data
+covariance). This is documented in the FA initialiser:
+"Use `0.0` to degrade gracefully to PCA."
+
+### Freezing readout and observation noise
+
+To keep PCA loadings and observation noise fixed during training:
+
+```python
+trainer_conf = OmegaConf.create(
+    {
+        "seed": 0,
+        "learning_rate": 1e-3,
+        "max_epoch": 200,
+        "batch_size": 32,
+        "validation_size": 32,
+        "freeze_paths": [
+            "observation.readout",
+            "observation.likelihood",
+        ],
+    }
+)
+```
+
+This freezes:
+- `observation.readout` — PCA loading matrix $C$ and bias $b$
+- `observation.likelihood` — observation noise $\sigma^2$
+
+Trainable parameters are then only:
+- dynamics (`state_map`)
+- state noise (`noise_free`)
+- encoders (`alpha_encoder`, `beta_encoder`)
+- prior (`unconstrained_prior_natural`)
+
+## Training and inference
+
+```python
+import jax.random as jr
+from jaxfads import XFADS
+from jaxfads.trainer import train
+from jaxfads.observations import GLM  # noqa: F401
+
+model = XFADS(conf, jr.key(0)).initialize(*data)
+trained = train(model, data, conf=trainer_conf)
+
+# Inference
+natural_params, moment_params, predictions = trained(
+    times, observations, controls, covariates, key=jr.key(1)
+)
+```
+
+## Interpretation
+
+- **`moment_params`** — posterior moments at each timestep. For small
+  $\sigma^2$, the posterior mean is close to PCA coordinates. For larger
+  $\sigma^2$, it is dynamics-smoothed.
+
+- **`predictions`** — predictive moments from the learned dynamics model.
+  The KL term in the ELBO compares posterior to prediction, which is how
+  dynamics receive gradient signal.
+
+- The learned dynamics $f$ and state noise $Q$ describe the temporal
+  structure of the latent process in PCA coordinates.
+
+## Equivalence to MSE regression
+
+In the limit $\sigma^2 \to 0$ with fixed $Q$, the ELBO dynamics gradient
+equals the MSE gradient on PCA coordinates
+([proof](pca_dynamics_equivalence.md)). With finite $\sigma^2$, the XFADS
+estimate is strictly richer because dynamics also receive gradient through
+the posterior's dependence on $f$.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,6 +86,7 @@ natural_params, moment_params, predictions = trained(
 | `mode` | `smooth` | Default offline smoothing-style inference (`alpha + beta`). |
 | `mode` | `causal` | Need Eq. 29-style causal recursion with smoothing reconstruction. |
 | `mode` | `nofilt` | Posterior set by custom encoder (e.g. pretrained DR); no filtering recursion. |
+| `state_map` | `IdentityStateMap` | Need a null/random-walk dynamics prior `z_{t+1}=z_t+noise`. |
 | `stepper` | `DiscreteStepper` | `dyn_conf.system_type="discrete"` and map already returns `z_{t+1}`. |
 | `stepper` | `EulerStepper` | Continuous-time map, faster/rougher integration. |
 | `stepper` | `RK4Stepper` | Continuous-time map, better local accuracy than Euler. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,7 +28,6 @@ conf = OmegaConf.create(
         "approx_kwargs": {},  # rank defaults to state_dim (full); use {"rank": r} for low-rank
         "state_map": "OUStateMap",
         "stepper": "EulerStepper",
-        "observation_model": "GLM",
         "dyn_conf": {
             "system_type": "continuous",
             "theta": 2.0,
@@ -43,9 +42,11 @@ conf = OmegaConf.create(
             "dropout": 0.0,
         },
         "obs_conf": {
-            "observation_likelihood": "Gaussian",
-            "observation_likelihood_kwargs": {"variance": 1.0},
-            "readout_structure": "linear",
+            "model": "GLM",
+            "likelihood": "Gaussian",
+            "cov": [1.0] * 10,
+            "norm_readout": False,
+            "readout_init": "fa",
             "readout_init_conf": {"obs_noise_var": 1.0},
         },
     }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,3 +104,4 @@ natural_params, moment_params, predictions = trained(
 - [Training Configuration](training.md)
 - [Algorithm Overview](algorithm.md)
 - [Paper Parity Review](paper_parity_2403_01371.md)
+- [Learning Dynamics from PCA Coordinates](pca_dynamics_workflow.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ from jaxfads.observations import GLM  # noqa: F401
 
 conf = OmegaConf.create(
     {
-        "mode": "smooth",  # "filter" | "smooth" | "causal"
+        "mode": "smooth",  # "filter" | "smooth" | "causal" | "nofilt"
         "state_dim": 4,
         "observation_dim": 10,
         "n_steps": 100,
@@ -85,6 +85,7 @@ natural_params, moment_params, predictions = trained(
 | `mode` | `filter` | Need alpha-only filtering natural parameters. |
 | `mode` | `smooth` | Default offline smoothing-style inference (`alpha + beta`). |
 | `mode` | `causal` | Need Eq. 29-style causal recursion with smoothing reconstruction. |
+| `mode` | `nofilt` | Posterior set by custom encoder (e.g. pretrained DR); no filtering recursion. |
 | `stepper` | `DiscreteStepper` | `dyn_conf.system_type="discrete"` and map already returns `z_{t+1}`. |
 | `stepper` | `EulerStepper` | Continuous-time map, faster/rougher integration. |
 | `stepper` | `RK4Stepper` | Continuous-time map, better local accuracy than Euler. |

--- a/src/jaxfads/base.py
+++ b/src/jaxfads/base.py
@@ -382,4 +382,30 @@ class Observation(SubclassRegistryMixin, ConfModule):
         ...
 
 
-__all__ = ["Approx", "StateMap", "Stepper", "Observation"]
+class Encoder(SubclassRegistryMixin, ConfModule):
+    """Abstract base class for observation encoders.
+
+    Subclasses are auto-registered and can be looked up via
+    ``Encoder.get_subclass(name)``.
+    """
+
+    @abstractmethod
+    def __call__(self, y: Array, *, key: Array | None = None) -> Array:
+        """Encode a single observation vector.
+
+        Parameters
+        ----------
+        y : Array, shape (observation_dim,)
+            Observation vector.
+        key : Array or None
+            Optional PRNG key for stochastic encoders.
+
+        Returns
+        -------
+        Array
+            Encoded representation. Shape depends on subclass.
+        """
+        ...
+
+
+__all__ = ["Approx", "StateMap", "Stepper", "Observation", "Encoder"]

--- a/src/jaxfads/core.py
+++ b/src/jaxfads/core.py
@@ -25,6 +25,7 @@ __all__ = [
     "filter",
     "smooth",
     "causal",
+    "nofilt",
 ]
 
 
@@ -127,6 +128,7 @@ class Mode(StrEnum):
     FILTER = auto()
     SMOOTH = auto()
     CAUSAL = auto()
+    NOFILT = auto()
 
 
 def _site_filter(
@@ -276,6 +278,39 @@ def causal(
     check_nature, _, moment_p = filter(model, key, _t, alpha, u, c)
     nature = check_nature + beta
     moment = jax.vmap(model.approx.natural_to_moment)(nature)
+    return nature, moment, moment_p
+
+
+def nofilt(
+    model,
+    key: Array,
+    _t: Array,
+    alpha: Array,
+    u: Array,
+    c: Array,
+) -> tuple[Array, Array, Array]:
+    """Non-filter mode: posterior from encoder only, no filtering recursion.
+
+    Posterior natural parameters are set directly by encoder output ``alpha``.
+    Predictive moments are computed in parallel for ELBO KL terms.
+    """
+    approx = model.approx
+    noise = approx.canon_to_moment(approx.free_to_canon(model.noise_free))
+
+    nature = alpha
+    moment = jax.vmap(approx.natural_to_moment)(nature)
+
+    expected_moment_fn = partial(
+        expected_predictive_moment,
+        f=model.transition,
+        noise=noise,
+        approx=approx,
+        mc_size=model.conf.mc_size,
+    )
+    keys = jrnd.split(key, nature.shape[0] - 1)
+    moment_p_rest = jax.vmap(expected_moment_fn)(keys, moment[:-1], u[:-1], c[:-1])
+    moment_p = jnp.vstack((moment[0:1], moment_p_rest))
+
     return nature, moment, moment_p
 
 

--- a/src/jaxfads/encoders.py
+++ b/src/jaxfads/encoders.py
@@ -22,12 +22,11 @@ from jax import Array, lax, vmap
 from jax import random as jrnd
 from omegaconf import DictConfig
 
-from gearax.modules import ConfModule
-
+from .base import Encoder
 from .nn import make_mlp
 
 
-class AlphaEncoder(ConfModule):
+class AlphaEncoder(Encoder):
     """Alpha encoder for observation-driven information updates in XFADS.
 
     The alpha encoder is a feedforward neural network that converts raw
@@ -76,7 +75,7 @@ class AlphaEncoder(ConfModule):
         return self.layer(y, key=key)
 
 
-class BetaEncoder(ConfModule):
+class BetaEncoder(Encoder):
     """Beta encoder for temporal dependency modeling in XFADS.
 
     The beta encoder is a GRU that processes sequences of alpha updates in
@@ -130,3 +129,5 @@ class BetaEncoder(ConfModule):
             hs = self.dropout(hs, key=key)
 
         return vmap(self.output)(hs)
+
+

--- a/src/jaxfads/smoother.py
+++ b/src/jaxfads/smoother.py
@@ -24,7 +24,7 @@ from .core import Mode
 from .base import Approx
 from .base import StateMap, Stepper
 from .nn import DataMasker
-from .base import Observation
+from .base import Observation, Encoder
 from .util import vmap_with_key
 from .logging import get_logger
 
@@ -122,7 +122,7 @@ class XFADS(ConfModule):
     # backward: StateMap | None
     observation: Observation
     alpha_encoder: Callable
-    beta_encoder: Callable
+    beta_encoder: Callable | None
     masker: DataMasker
     unconstrained_prior_natural: Any
     noise_free: Any
@@ -207,20 +207,29 @@ class XFADS(ConfModule):
         free_size = int(self.approx.free_size())
         param_size = int(self.approx.param_size())
 
+        is_nofilt_mode = str(self.conf.mode).lower() == str(Mode.NOFILT)
+        enc_free_size = int(self.conf.state_dim) if is_nofilt_mode else free_size
+
         enc_conf = OmegaConf.merge(
             self.conf.enc_conf,
             {
                 "observation_dim": self.conf.observation_dim,
+                "state_dim": self.conf.state_dim,
                 "param_size": param_size,
-                "free_size": free_size,
+                "free_size": enc_free_size,
             },
         )
 
         key, ky = jrnd.split(key)
-        self.alpha_encoder = encoders.AlphaEncoder(enc_conf, ky)
+        encoder_name = enc_conf.get("alpha_encoder", "AlphaEncoder")
+        encoder_cls = Encoder.get_subclass(encoder_name)
+        self.alpha_encoder = encoder_cls(enc_conf, ky)
 
-        key, ky = jrnd.split(key)
-        self.beta_encoder = encoders.BetaEncoder(enc_conf, ky)
+        if is_nofilt_mode:
+            self.beta_encoder = None
+        else:
+            key, ky = jrnd.split(key)
+            self.beta_encoder = encoders.BetaEncoder(enc_conf, ky)
 
         # if "s" in static_params:
         #     self.state_map.set_static()
@@ -256,7 +265,7 @@ class XFADS(ConfModule):
         Delegates initialization to the observation model.
         """
         observation = self.observation.initialize(t, y, u, c)
-        return eqx.tree_at(lambda model: model.observation, self, observation)
+        return eqx.tree_at(lambda m: m.observation, self, observation)
 
     @classmethod
     def load(cls, path: str | Path):
@@ -405,7 +414,9 @@ class XFADS(ConfModule):
 
         batch_free_to_natural = vmap(vmap(_free_to_natural))
         batch_alpha_encode = vmap_with_key(vmap_with_key(self.alpha_encoder))
-        batch_beta_encode = vmap_with_key(self.beta_encoder)
+        batch_beta_encode = (
+            None if self.beta_encoder is None else vmap_with_key(self.beta_encoder)
+        )
 
         def batch_encode_alpha(y: Array, key) -> Array:
             # handling missing values
@@ -425,6 +436,8 @@ class XFADS(ConfModule):
             return a
 
         def batch_encode_beta(a: Array, key) -> Array:
+            if batch_beta_encode is None:
+                raise ValueError("beta_encoder is required for non-NOFILT modes")
             key, beta_key = jrnd.split(key)
             b_free = batch_beta_encode(a, key=beta_key)
             b = batch_free_to_natural(b_free)
@@ -436,23 +449,45 @@ class XFADS(ConfModule):
             return b
 
         alpha_key, beta_key, rest_key = jrnd.split(key, 3)
-        a = batch_encode_alpha(y, alpha_key)
         keys = jrnd.split(rest_key, jnp.size(t, 0))
 
         match self.conf.mode:
             case Mode.FILTER:
+                a = batch_encode_alpha(y, alpha_key)
                 smooth_batch = vmap(partial(core.filter, self))
                 return smooth_batch(keys, t, a, u, c)
             case Mode.CAUSAL:
+                a = batch_encode_alpha(y, alpha_key)
                 b = batch_encode_beta(a, beta_key)
                 smooth_batch = vmap(partial(core.causal, self))
                 return smooth_batch(keys, t, a, b, u, c)
             case Mode.SMOOTH:
+                a = batch_encode_alpha(y, alpha_key)
                 b = batch_encode_beta(a, beta_key)
                 smooth_batch = vmap(partial(core.smooth, self))
                 return smooth_batch(keys, t, a, b, u, c)
+            case Mode.NOFILT:
+                batch_roll_encode = vmap_with_key(vmap_with_key(self.alpha_encoder))
+
+                mask_y = jnp.all(jnp.isfinite(y), axis=2, keepdims=True)
+                y_clean = jnp.where(mask_y, y, 0)
+                z_hat = batch_roll_encode(y_clean, key=alpha_key)
+
+                eps = float(self.conf.get("nofilt_eps", 1e-6))
+
+                def _pack_point(z):
+                    cov = eps * jnp.eye(self.conf.state_dim)
+                    mom = approx.pack(z, cov)
+                    return approx.moment_to_natural(mom)
+
+                a_roll = vmap(vmap(_pack_point))(z_hat)
+                prior_nat = self.prior_natural()
+                a_roll = jnp.where(mask_y, a_roll, prior_nat)
+
+                nofilt_batch = vmap(partial(core.nofilt, self))
+                return nofilt_batch(keys, t, a_roll, u, c)
             case _:
                 raise ValueError(
                     f"Unsupported mode: {self.conf.mode}. Expected one of "
-                    f"{Mode.FILTER!s}, {Mode.SMOOTH!s}, {Mode.CAUSAL!s}."
+                    f"{Mode.FILTER!s}, {Mode.SMOOTH!s}, {Mode.CAUSAL!s}, {Mode.NOFILT!s}."
                 )

--- a/src/jaxfads/smoother.py
+++ b/src/jaxfads/smoother.py
@@ -207,7 +207,7 @@ class XFADS(ConfModule):
         free_size = int(self.approx.free_size())
         param_size = int(self.approx.param_size())
 
-        is_nofilt_mode = str(self.conf.mode).lower() == str(Mode.NOFILT)
+        is_nofilt_mode = str(self.conf.mode) == str(Mode.NOFILT)
         enc_free_size = int(self.conf.state_dim) if is_nofilt_mode else free_size
 
         enc_conf = OmegaConf.merge(
@@ -467,11 +467,14 @@ class XFADS(ConfModule):
                 smooth_batch = vmap(partial(core.smooth, self))
                 return smooth_batch(keys, t, a, b, u, c)
             case Mode.NOFILT:
-                batch_roll_encode = vmap_with_key(vmap_with_key(self.alpha_encoder))
-
+                if not hasattr(approx, "pack"):
+                    raise NotImplementedError(
+                        "NOFILT mode currently requires an Approx with pack() "
+                        "(e.g. MVN)."
+                    )
                 mask_y = jnp.all(jnp.isfinite(y), axis=2, keepdims=True)
                 y_clean = jnp.where(mask_y, y, 0)
-                z_hat = batch_roll_encode(y_clean, key=alpha_key)
+                z_hat = batch_alpha_encode(y_clean, key=alpha_key)
 
                 eps = float(self.conf.get("nofilt_eps", 1e-6))
 

--- a/src/jaxfads/state_maps/__init__.py
+++ b/src/jaxfads/state_maps/__init__.py
@@ -5,11 +5,13 @@ Importing this package registers built-in subclasses via
 
 Built-ins
 ---------
+- `IdentityStateMap`: discrete random-walk mean map
 - `OUStateMap`: zero-mean Ornstein–Uhlenbeck drift map
 - `FunctionStateMap`: wrapper around plain Python functions/methods/partials
 """
 
 from .function import FunctionStateMap
+from .identity import IdentityStateMap
 from .ou import OUStateMap
 
-__all__ = ["OUStateMap", "FunctionStateMap"]
+__all__ = ["IdentityStateMap", "OUStateMap", "FunctionStateMap"]

--- a/src/jaxfads/state_maps/identity.py
+++ b/src/jaxfads/state_maps/identity.py
@@ -1,0 +1,44 @@
+"""Minimal discrete state maps.
+
+This module provides an identity/random-walk mean state map.
+
+Notes
+-----
+This codebase keeps process noise on `XFADS` (configured via
+`dyn_conf.state_noise`). `IdentityStateMap` implements only the deterministic
+mean map ``z_{t+1} = z_t``; the full latent evolution is therefore the random
+walk ``z_{t+1} = z_t + noise``.
+"""
+
+from __future__ import annotations
+
+from jax import Array
+
+from ..base import StateMap
+
+
+class IdentityStateMap(StateMap):
+    """Discrete random-walk mean map: ``z_{t+1} = z_t + noise``.
+
+    This state map contributes the deterministic identity mean map
+    ``f(z_t) = z_t``; process noise remains configured on `XFADS` via
+    ``dyn_conf.state_noise``.
+
+    Notes
+    -----
+    Controls/covariates `u` and `c` are ignored. This map requires
+    ``dyn_conf.system_type='discrete'``.
+    """
+
+    def __init__(self, conf, key: Array):
+        del key
+        self.conf = conf
+        if str(conf.system_type) != "discrete":
+            raise ValueError(
+                "IdentityStateMap requires dyn_conf.system_type='discrete'."
+            )
+
+    def eval(self, z: Array, u: Array, c: Array, *, key=None) -> Array:
+        """Discrete identity mean map: ``f(z_t) = z_t``."""
+        del u, c, key
+        return z

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
+import equinox as eqx
+from jax import Array
 
-from jaxfads.base import Approx
+from jaxfads.base import Approx, StateMap
 from jaxfads.distributions import MVN
 
 _STATE_DIM = 2
@@ -36,3 +38,16 @@ def make_approx(dim: int, approx_name: str = "MVN", **kwargs) -> Approx:
 def make_noise(approx: Approx, state_dim: int, cov: float = 1.0):
     """Create noise transition params (flat) for test use."""
     return approx.canon_to_moment(approx.free_to_canon(approx.free_from_kw(scale=cov)))
+
+
+class MockStateMap(StateMap):
+    """Mock dynamics — identity transition. Shared across test modules."""
+
+    layer: eqx.Module | None
+
+    def __init__(self, conf, key: Array = None):
+        self.conf = conf
+        self.layer = None
+
+    def eval(self, z: Array, u: Array, c: Array, *, key: Array | None = None) -> Array:
+        return z

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,44 @@
-"""Deprecated: core algorithm tests were consolidated into `test_algorithm.py`.
+from types import SimpleNamespace
 
-This file intentionally contains no tests.
-"""
+import chex
+from jax import numpy as jnp
+from jax import random as jr
+
+from jaxfads import core
+from jaxfads.distributions import MVN
+
+
+class _DummyModel:
+    def __init__(self, state_dim: int, mc_size: int = 1):
+        self.approx = MVN(dim=state_dim, rank=state_dim)
+        self.conf = SimpleNamespace(mc_size=mc_size)
+        self.noise_free = self.approx.free_from_kw(scale=1.0)
+
+    def transition(self, z, u, c, *, key=None):
+        del u, c, key
+        return z
+
+    def prior_natural(self):
+        return self.approx.moment_to_natural(
+            self.approx.canon_to_moment(
+                self.approx.free_to_canon(self.approx.free_from_kw(scale=1.0))
+            )
+        )
+
+
+def test_nofilt_shapes_and_finite():
+    state_dim, T = 3, 6
+    model = _DummyModel(state_dim=state_dim, mc_size=2)
+
+    param_dim = model.approx.param_size()
+    alpha = jnp.vstack([model.prior_natural()] * T)
+    u = jnp.zeros((T, 0))
+    c = jnp.zeros((T, 0))
+
+    nature, moment, moment_p = core.nofilt(model, jr.key(1), jnp.arange(T), alpha, u, c)
+
+    for arr in (nature, moment, moment_p):
+        chex.assert_shape(arr, (T, param_dim))
+        chex.assert_tree_all_finite(arr)
+
+    chex.assert_trees_all_close(nature, alpha, atol=1e-6)

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,4 +1,0 @@
-"""Deprecated: algorithm-level dynamics tests were consolidated into `test_algorithm.py`.
-
-This file intentionally contains no tests.
-"""

--- a/tests/test_dynamics_ou.py
+++ b/tests/test_dynamics_ou.py
@@ -1,4 +1,5 @@
 import chex
+import pytest
 from jax import numpy as jnp
 from jax import random as jr
 from omegaconf import OmegaConf
@@ -38,3 +39,46 @@ def test_ou_state_map_registry_and_euler_step():
     chex.assert_trees_all_close(out, expected, atol=1e-6)
     chex.assert_shape(out, (state_dim,))
     chex.assert_tree_all_finite(out)
+
+
+def test_identity_state_map_registry_and_discrete_step():
+    map_cls = StateMap.get_subclass("IdentityStateMap")
+    stepper_cls = Stepper.get_subclass("DiscreteStepper")
+
+    state_dim = 4
+    conf = OmegaConf.create(
+        dict(
+            state_dim=state_dim,
+            observation_dim=1,
+            input_dim=0,
+            context_dim=0,
+            system_type="discrete",
+        )
+    )
+
+    state_map = map_cls(conf, key=jr.key(0))
+    stepper = stepper_cls(conf)
+
+    z = jr.normal(jr.key(1), (state_dim,))
+    out = stepper.step(z, jnp.zeros((0,)), jnp.zeros((0,)), state_map)
+
+    chex.assert_trees_all_close(out, z, atol=1e-6)
+    chex.assert_shape(out, (state_dim,))
+    chex.assert_tree_all_finite(out)
+
+
+def test_identity_state_map_rejects_continuous_system_type():
+    conf = OmegaConf.create(
+        dict(
+            state_dim=2,
+            observation_dim=1,
+            input_dim=0,
+            context_dim=0,
+            system_type="continuous",
+        )
+    )
+
+    with pytest.raises(
+        ValueError, match="IdentityStateMap requires dyn_conf.system_type='discrete'."
+    ):
+        StateMap.get_subclass("IdentityStateMap")(conf, key=jr.key(0))

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -3,6 +3,7 @@ from jax import numpy as jnp
 from jax import random as jrnd
 from omegaconf import OmegaConf
 
+from jaxfads.base import Encoder
 from jaxfads.encoders import AlphaEncoder, BetaEncoder
 from conftest import make_approx
 
@@ -74,3 +75,37 @@ def test_beta_encoder_supports_param_and_free_size_contract():
     out = encoder(a)
     chex.assert_shape(out, (4, int(conf.free_size)))
     chex.assert_tree_all_finite(out)
+
+
+def test_custom_encoder_subclass_shape():
+    class SliceEncoder(Encoder):
+        def __init__(self, conf, key=None):
+            del key
+            self.conf = conf
+
+        def __call__(self, y, *, key=None):
+            del key
+            return y[: int(self.conf.state_dim)]
+
+    conf = OmegaConf.create(dict(observation_dim=5, state_dim=2))
+    enc = SliceEncoder(conf)
+    y = jnp.arange(5.0)
+    out = enc(y)
+    chex.assert_shape(out, (2,))
+    chex.assert_tree_all_finite(out)
+
+
+def test_custom_encoder_registry_lookup():
+    class ScaleEncoder(Encoder):
+        def __init__(self, conf, key=None):
+            del key
+            self.conf = conf
+
+        def __call__(self, y, *, key=None):
+            del key
+            return 2.0 * y[: int(self.conf.state_dim)]
+
+    conf = OmegaConf.create(dict(observation_dim=4, state_dim=3))
+    cls = Encoder.get_subclass("ScaleEncoder")
+    out = cls(conf)(jnp.ones((4,)))
+    chex.assert_trees_all_close(out, 2.0 * jnp.ones((3,)), atol=1e-6)

--- a/tests/test_smoother.py
+++ b/tests/test_smoother.py
@@ -7,7 +7,7 @@ from jax import numpy as jnp
 from omegaconf import OmegaConf, DictConfig
 import equinox as eqx
 import pytest
-from jaxfads.base import StateMap
+from jaxfads.base import StateMap, Encoder
 from jaxfads.smoother import XFADS
 
 
@@ -23,6 +23,18 @@ class Mock(StateMap):
     @override
     def eval(self, z: Array, u: Array, c: Array, *, key: Array | None = None) -> Array:
         return z
+
+
+class IdentityEncoder(Encoder):
+    """Test encoder: returns first state_dim components of y."""
+
+    def __init__(self, conf: DictConfig, key: Array | None = None):
+        del key
+        self.conf = conf
+
+    def __call__(self, y: Array, *, key: Array | None = None) -> Array:
+        del key
+        return y[: int(self.conf.state_dim)]
 
 
 def test_constructor():
@@ -423,7 +435,7 @@ def test_invalid_mode_error_lists_filter_smooth_causal():
     c = jnp.zeros((1, T, 0))
 
     model = model.initialize(times, y, u, c)
-    with pytest.raises(ValueError, match="filter, smooth, causal"):
+    with pytest.raises(ValueError, match="filter, smooth, causal, nofilt"):
         model(times, y, u, c, key=jr.key(2))
 
 
@@ -485,5 +497,67 @@ def test_filter_mode_skips_beta_encoder():
     model = model.initialize(times, y, u, c)
     _, post_mom, prior_mom = model(times, y, u, c, key=jr.key(2))
 
+    assert jnp.isfinite(post_mom).all()
+    assert jnp.isfinite(prior_mom).all()
+
+
+def test_xfads_nofilt_mode():
+    """XFADS should run end-to-end with mode='nofilt' and custom Encoder."""
+    T = 5
+    y_size = 6
+    z_size = 2
+
+    model_conf = OmegaConf.create(
+        dict(
+            mode="nofilt",
+            observation_dim=y_size,
+            state_dim=z_size,
+            state_map="Mock",
+            stepper="DiscreteStepper",
+            approx="MVN",
+            approx_kwargs={},
+            mc_size=2,
+            seed=0,
+            n_steps=T,
+            fb_penalty=0,
+            noise_penalty=0,
+            dropout=0.0,
+            nofilt_eps=1e-6,
+            dyn_conf=OmegaConf.create(
+                dict(
+                    input_dim=0,
+                    context_dim=0,
+                    state_noise=1.0,
+                    system_type="discrete",
+                )
+            ),
+            enc_conf=OmegaConf.create(
+                dict(alpha_encoder="IdentityEncoder", width=8, depth=1, dropout=0.0)
+            ),
+            obs_conf=OmegaConf.create(
+                dict(
+                    model="GLM",
+                    likelihood="Gaussian",
+                    cov=[1e-3] * y_size,
+                    norm_readout=False,
+                    readout_init="fa",
+                    readout_init_conf=dict(obs_noise_var=0.0),
+                )
+            ),
+        )
+    )
+
+    model = XFADS(model_conf, jr.key(0))
+    assert model.beta_encoder is None
+
+    times = jnp.broadcast_to(jnp.arange(T), (1, T))
+    y = jr.normal(jr.key(1), (1, T, y_size))
+    u = jnp.zeros((1, T, 0))
+    c = jnp.zeros((1, T, 0))
+
+    model = model.initialize(times, y, u, c)
+    nature, post_mom, prior_mom = model(times, y, u, c, key=jr.key(2))
+
+    assert jnp.isfinite(nature).all()
     assert jnp.isfinite(post_mom).all()
     assert jnp.isfinite(prior_mom).all()

--- a/tests/test_smoother.py
+++ b/tests/test_smoother.py
@@ -1,4 +1,3 @@
-from typing import override
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -7,22 +6,9 @@ from jax import numpy as jnp
 from omegaconf import OmegaConf, DictConfig
 import equinox as eqx
 import pytest
-from jaxfads.base import StateMap, Encoder
+from jaxfads.base import Encoder
 from jaxfads.smoother import XFADS
-
-
-class Mock(StateMap):
-    """Mock dynamics — pure deterministic transition."""
-
-    layer: eqx.Module | None
-
-    def __init__(self, conf: DictConfig, key: Array):
-        self.conf = conf
-        self.layer = None
-
-    @override
-    def eval(self, z: Array, u: Array, c: Array, *, key: Array | None = None) -> Array:
-        return z
+from conftest import MockStateMap  # noqa: F401 - class registration side-effect
 
 
 class IdentityEncoder(Encoder):
@@ -57,7 +43,7 @@ def test_constructor():
             mode="smooth",
             observation_dim=y_size,
             state_dim=z_size,
-            state_map="Mock",
+            state_map="MockStateMap",
             stepper="DiscreteStepper",
             approx="MVN",
             approx_kwargs={},
@@ -128,7 +114,7 @@ def test_top_level_dims_override_subconfig_dims():
             mode="smooth",
             observation_dim=y_size,
             state_dim=z_size,
-            state_map="Mock",
+            state_map="MockStateMap",
             stepper="DiscreteStepper",
             approx="MVN",
             approx_kwargs={},
@@ -198,147 +184,26 @@ def test_top_level_dims_override_subconfig_dims():
     assert jnp.isfinite(prior_mom).all()
 
 
-def test_low_rank_mvn_smoke_constructor_and_forward_pass():
-    """XFADS should run end-to-end with low-rank MVN encoder outputs."""
+@pytest.mark.parametrize("mode,approx_kwargs", [
+    ("smooth", {"rank": 2}),
+    ("causal", {}),
+    ("filter", {}),
+])
+def test_mode_smoke_forward_pass(mode, approx_kwargs):
+    """XFADS should run end-to-end for each standard inference mode."""
     T = 5
     y_size = 4
     z_size = 3
 
     model_conf = OmegaConf.create(
         dict(
-            mode="smooth",
+            mode=mode,
             observation_dim=y_size,
             state_dim=z_size,
-            state_map="Mock",
+            state_map="MockStateMap",
             stepper="DiscreteStepper",
             approx="MVN",
-            approx_kwargs={"rank": 2},
-            mc_size=2,
-            seed=0,
-            n_steps=T,
-            fb_penalty=0,
-            noise_penalty=0,
-            dropout=0.0,
-            dyn_conf=OmegaConf.create(
-                dict(
-                    input_dim=0,
-                    context_dim=0,
-                    state_noise=1.0,
-                    system_type="discrete",
-                )
-            ),
-            enc_conf=OmegaConf.create(
-                dict(
-                    width=8,
-                    depth=1,
-                    dropout=0.0,
-                )
-            ),
-            obs_conf=OmegaConf.create(
-                dict(
-                    model="GLM",
-                    emission_noise=1.0,
-                    norm_readout=False,
-                    dropout=0.0,
-                    likelihood="Poisson",
-                )
-            ),
-        )
-    )
-
-    key = jr.key(0)
-    model = XFADS(model_conf, key)
-
-    times = jnp.broadcast_to(jnp.arange(T), (1, T))
-    y = jr.poisson(jr.key(1), jnp.ones((1, T, y_size)))
-    u = jnp.zeros((1, T, 0))
-    c = jnp.zeros((1, T, 0))
-
-    model = model.initialize(times, y, u, c)
-    _, post_mom, prior_mom = model(times, y, u, c, key=jr.key(2))
-
-    assert jnp.isfinite(post_mom).all()
-    assert jnp.isfinite(prior_mom).all()
-
-
-def test_causal_mode_smoke_constructor_and_forward_pass():
-    """XFADS should run end-to-end with mode='causal'."""
-    T = 5
-    y_size = 4
-    z_size = 3
-
-    model_conf = OmegaConf.create(
-        dict(
-            mode="causal",
-            observation_dim=y_size,
-            state_dim=z_size,
-            state_map="Mock",
-            stepper="DiscreteStepper",
-            approx="MVN",
-            approx_kwargs={},
-            mc_size=2,
-            seed=0,
-            n_steps=T,
-            fb_penalty=0,
-            noise_penalty=0,
-            dropout=0.0,
-            dyn_conf=OmegaConf.create(
-                dict(
-                    input_dim=0,
-                    context_dim=0,
-                    state_noise=1.0,
-                    system_type="discrete",
-                )
-            ),
-            enc_conf=OmegaConf.create(
-                dict(
-                    width=8,
-                    depth=1,
-                    dropout=0.0,
-                )
-            ),
-            obs_conf=OmegaConf.create(
-                dict(
-                    model="GLM",
-                    emission_noise=1.0,
-                    norm_readout=False,
-                    dropout=0.0,
-                    likelihood="Poisson",
-                )
-            ),
-        )
-    )
-
-    key = jr.key(0)
-    model = XFADS(model_conf, key)
-
-    times = jnp.broadcast_to(jnp.arange(T), (1, T))
-    y = jr.poisson(jr.key(1), jnp.ones((1, T, y_size)))
-    u = jnp.zeros((1, T, 0))
-    c = jnp.zeros((1, T, 0))
-
-    model = model.initialize(times, y, u, c)
-    _, post_mom, prior_mom = model(times, y, u, c, key=jr.key(2))
-
-    assert jnp.isfinite(post_mom).all()
-    assert jnp.isfinite(prior_mom).all()
-
-
-def test_filter_mode_smoke_constructor_and_forward_pass():
-    """XFADS should run end-to-end with mode='filter'."""
-    T = 5
-    y_size = 4
-    z_size = 3
-
-    model_conf = OmegaConf.create(
-        dict(
-            mode="filter",
-            observation_dim=y_size,
-            state_dim=z_size,
-            state_map="Mock",
-            stepper="DiscreteStepper",
-            approx="MVN",
-            approx_kwargs={},
+            approx_kwargs=approx_kwargs,
             mc_size=2,
             seed=0,
             n_steps=T,
@@ -397,7 +262,7 @@ def test_invalid_mode_error_lists_filter_smooth_causal():
             mode="unknown",
             observation_dim=y_size,
             state_dim=z_size,
-            state_map="Mock",
+            state_map="MockStateMap",
             stepper="DiscreteStepper",
             approx="MVN",
             approx_kwargs={},
@@ -450,7 +315,7 @@ def test_filter_mode_skips_beta_encoder():
             mode="filter",
             observation_dim=y_size,
             state_dim=z_size,
-            state_map="Mock",
+            state_map="MockStateMap",
             stepper="DiscreteStepper",
             approx="MVN",
             approx_kwargs={},
@@ -512,7 +377,7 @@ def test_xfads_nofilt_mode():
             mode="nofilt",
             observation_dim=y_size,
             state_dim=z_size,
-            state_map="Mock",
+            state_map="MockStateMap",
             stepper="DiscreteStepper",
             approx="MVN",
             approx_kwargs={},

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,27 +1,13 @@
 import pytest
 import jax
-from jax import Array, numpy as jnp, random as jrnd
-import equinox as eqx
+from jax import numpy as jnp, random as jrnd
 import chex
 from omegaconf import OmegaConf
 
 from jaxfads.trainer import train
 from jaxfads.smoother import XFADS
-from jaxfads.base import StateMap
 import jaxfads.observations  # noqa: F401 — register GLM subclass
-
-
-class MockStateMap(StateMap):
-    """Mock dynamics for testing — pure deterministic identity."""
-
-    layer: eqx.Module | None
-
-    def __init__(self, conf, key):
-        self.conf = conf
-        self.layer = None
-
-    def eval(self, z, u, c, *, key=None) -> Array:
-        return z
+from conftest import MockStateMap  # noqa: F401 - class registration side-effect
 
 
 @pytest.fixture

--- a/tests/test_trainer_regularizer.py
+++ b/tests/test_trainer_regularizer.py
@@ -3,24 +3,12 @@ import jax.numpy as jnp
 import chex
 import pytest
 import equinox as eqx
-from jax import Array
 from omegaconf import OmegaConf
 
-from jaxfads.base import StateMap
 from jaxfads.smoother import XFADS
 from jaxfads.trainer import batch_loss
 import jaxfads.observations  # noqa: F401 — register GLM subclass
-
-
-class MockStateMap(StateMap):
-    layer: eqx.Module | None
-
-    def __init__(self, conf, key: Array):
-        self.conf = conf
-        self.layer = None
-
-    def eval(self, z: Array, u: Array, c: Array, *, key=None) -> Array:
-        return z
+from conftest import MockStateMap  # noqa: F401 - class registration side-effect
 
 
 @pytest.fixture

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -1,4 +1,0 @@
-"""Deprecated: ELBO tests were consolidated into `test_algorithm.py`.
-
-This file intentionally contains no tests.
-"""


### PR DESCRIPTION
## Summary
- add `NOFILT` inference mode for fitting dynamics to fixed latent trajectories from user-defined `Encoder` subclasses
- add PCA-focused docs and benchmarks, including empirical verification of the ELBO/MSE gradient equivalence and an end-to-end NOFILT PCA comparison
- add `IdentityStateMap` as a built-in null/random-walk baseline for discrete dynamics
- tidy tests/docs and address review issues in the NOFILT path

## What changed
- introduce `Encoder` ABC and make `AlphaEncoder`/`BetaEncoder` encoder subclasses
- add `core.nofilt()` and wire `mode="nofilt"` through `XFADS`
- add fail-fast NOFILT validation for `Approx.pack()`, remove mode-case mismatch, and deduplicate the NOFILT encoder call path
- document PCA workflows for both small-noise smoothing and NOFILT custom encoders
- add `IdentityStateMap` docs/tests and use it as the null baseline in the PCA benchmark
- consolidate duplicated tests and remove deprecated empty test files

## Validation
- `uv run pytest -q` → `87 passed, 1 warning`
- `uv run python benchmarks/pca_dynamics_verification.py`
  - Section 1 (gradient equivalence): cosine similarity ≈ 1.0 across eps values
  - Section 2 (NOFILT end-to-end):
    - `Identity pred RMSE: 1.484019`
    - `OLS pred RMSE: 1.073376`
    - `XFADS pred RMSE: 1.073781`
    - `||W_xfads - A_ols||_F: 0.026735`

## Notes
- `examples/vdp_example.py` is intentionally unchanged; `IdentityStateMap` is added as a null baseline, not as a replacement for the OU baseline there.
